### PR TITLE
Add Python package layout guidelines

### DIFF
--- a/docs/How do we lay out public and private modules in a Python package?.md
+++ b/docs/How do we lay out public and private modules in a Python package?.md
@@ -104,12 +104,11 @@ This is done for convenience:
 
 2. It makes it easier when you want to reorganize the code within the `h.models` package. For example renaming a module, splitting a large module into two smaller ones, or joining two modules into one. Code that does `from h.models import Annotation, Group, User` won't be broken by the reorganization
 
-### This doesn't mean every module is internal
+### Don't underscore modules just because their names are imported into `__init__.py`
 
-You might think that, since `Annotation`, `Group` and `User` are meant to be imported from `models/__init__.py` rather than from `models/annotation.py`, `models/group.py` and `models/user.py`, that `models/annotation.py`, `models/group.py` and `models/user.py` are actually internal and should have leading underscores. Don't think this, though, because it would mean that:
+If all of a module's public names are imported into the nearest `__init__.py` that **doesn't** mean the module is internal and should have a leading underscore in its filename. Just leave the module without a leading underscore.
 
-1. Every module in every package would have a leading underscore
-2. The leading underscores would no longer be helping us to distinguish between modules that contain public things and modules that only contain internal collaborators
+This is because packages that import public names into `__init__.py` tend to import the public names from _all_ of their modules. So if we marked the modules whose names are imported as internal, we'd end up marking _every_ module in the package as internal. The leading underscores would no longer be helping us to distinguish between modules that contain public things and modules that only contain internal collaborators. The underscores would just be visual noise, providing no information.
 
 ## We don't use `__all__`
 

--- a/docs/How do we lay out public and private modules in a Python package?.md
+++ b/docs/How do we lay out public and private modules in a Python package?.md
@@ -13,7 +13,7 @@ Some packages can be installed and might even be published to the [Python Packag
 
 ## Aims
 
-We want an approach to laying out out our packages that:
+We want an approach to laying out our packages that:
 
 * Differentiates the public interface (that's meant to be called from outside of the package) from internal code.
 
@@ -27,7 +27,7 @@ We want an approach to laying out out our packages that:
 
   In the past we've used an `<APP>.util` package to contain "utilities" that don't seem to belong anywhere else. This is a terrible pattern because `<APP>.util` becomes an ill-defined grab-bag of all sorts of random stuff, and because anything in `<APP>.util` looks like it might be used anywhere in the code whereas in fact it's likely only used in one place: localization breaks down. We don't want any more `<APP>.util` packages.
 
-  Also in the past we've created local `helpers.py` modules or `helpers/` packages within packages to contain the utils or helpers just for that package. This isn't a good pattern either: it still ends up moving close collaborators away from the code that uses them, splitting functions that should live together in one module into separate modules by forcing the helper into `helpers.py`, or splitting modules that should live side-by-side in one package into separate packages by forcing the helper into a `helpers/` sub-package. It's also just annoying to always have to move everything into "helpers" modules.
+  Also in the past we've created local `helpers.py` modules or `helpers/` packages within packages to contain the utils or helpers just for that package. This isn't a good pattern either: it still ends up moving close collaborators away from the code that uses them, splitting functions that should live together in one module into separate modules by forcing the helper into `helpers.py`, or splitting modules that should live side-by-side in one package into separate packages by forcing the helper into a `helpers/` subpackage. It's also just annoying to always have to move everything into "helpers" modules.
 
 ## Approach
 
@@ -37,13 +37,13 @@ Our approach is simple:
 
 2. Names that are **not** part of a class, module or (sub)package's public interface **do** have a leading underscore
 
-3. The "public interface" of a class, module or (sub)package means all the names that are meant to be called by **code outside of that package**. The public names could be called by code from other (sub)packages of the same app, or they could be called by third-party frameworks such as Pyramid (for example when Pyramid calls an app's views), etc.
+3. The "public interface" of a class, module or (sub)package means all the names that are meant to be called by **code outside of that package**. The public names could be called by code from other class, modules or (sub)packages of the same app, or they could be called by third-party frameworks such as Pyramid (for example when Pyramid calls an app's views), etc.
 
 4. For example:
 
    1. **Classes:** public attributes and methods of a class don't have leading underscores. Private attributes and methods within a class do have leading underscores.
    2. **Modules:** public classes, functions and other top-level names within a module don't have leading underscores. Private attributes, methods and names within a module do have leading underscores.
-   3. **Packages:** public modules within a package don't have leading underscores on their filenames, e.g. `foo.py`. Private modules within a package do have leading underscore, e.g. `_foo.py`. Similarly a public subpackage would have no leading underscore (`bar/`), a private subpackage would have a leading underscore (`_bar/`).
+   3. **Packages:** public modules within a package don't have leading underscores on their filenames, e.g. `foo.py`. Private modules within a package do have leading underscores, e.g. `_foo.py`. Similarly a public subpackage would have no leading underscore (`bar/`), a private subpackage would have a leading underscore (`_bar/`).
 
 This approach is inspired by [PEP 8](https://www.python.org/dev/peps/pep-0008/)'s guidelines on [public and internal interfaces](https://www.python.org/dev/peps/pep-0008/#public-and-internal-interfaces), which say:
 
@@ -63,15 +63,16 @@ Generally there are three different types of package within an app:
 
    * View classes and view methods are public interface: Pyramid calls our views to get responses to requests
      * Exception views are also public interface: Pyramid calls these too
-   * Custom view predicates (which get used in Pyramid `@view_config`'s) are public interface: Pyramid calls out view predicates to determine whether to call the view or not
+   * Custom view predicates (which get used in Pyramid `@view_config`'s) are public interface: Pyramid calls our view predicates to determine whether to call the view or not
    * Helper functions that the views call are not public interface: these are only called by other code within the same package. They're not directly called by Pyramid
 
    So in the case of an `<APP>.views` package the leading underscores differentiate the views and other things that're registered with Pyramid, from internal helpers. The differentiation helps you to see what views, predicates, etc the app has without being distracted by all their collaborators.
 
 3. Some packages will be a bit of both (1) and (2)
 
-## Exceptio
-* Pyramid [exception views](https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/views.html#custom-exception-views) present a view-specific code layout issue: you'll probably want to put them in an `exceptions.py` file, but `exceptions.py` is the name that we use in all of our packages for the module that contains that package's exception classes. Decision: just put both custom exception classes (if the `views` package has any) and Pyramid exception views both together in `views/exceptions.py` (no leading underscore)
+## Exception Views Module Naming
+
+Pyramid [exception views](https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/views.html#custom-exception-views) present a view-specific code layout issue: you'll probably want to put them in an `exceptions.py` file, but `exceptions.py` is the name that we use in all of our packages for the module that contains that package's exception classes. Decision: just put both custom exception classes (if the `views` package has any) and Pyramid exception views both together in `views/exceptions.py` (no leading underscore)
 
 ## In-module collaborators
 

--- a/docs/How do we lay out public and private modules in a Python package?.md
+++ b/docs/How do we lay out public and private modules in a Python package?.md
@@ -4,24 +4,29 @@ See also:
 
 * [Organization of views package is poor](https://github.com/hypothesis/lms/issues/1245), the original issue that led to this file
 
-## What Is a Python "Package"?
+We have a very simple approach:
 
-For the purposes of this document a "package" is a directory containing an `__init__.py` file and possibly other Python files and packages. A package can be inside another package (in which case it can be called a "subpackage").
-Packages are a way of structuring the module namespace within a containing package or app. See [Packages in the Python tutorial](https://docs.python.org/3/tutorial/modules.html#packages) for more on this definition of package.
+1. A "package" is any directory that contains an `__init__.py` file
 
-Some packages can be installed and might even be published to the [Python Package Index (PyPI.org)](https://pypi.org/). **This document isn't limited to just installable packages** -- packages and subpackages within a containing package or app are also "packages" for this document's purposes.
+2. The "public interface" of a class, module or package is all the names that're used by code outside of that class module or package
 
-## What Is a "Public Interface"?
+   The calling code can be other code within the same app or it can be a third-party framework. For example Pyramid calls our view functions, so the view functions are part of the `<APP>.views` package's public interface.
 
-For the purposes of this document the "public interface" of a class, module or package is all the names that are meant to be used by **code outside of that class, module or package**. The public names could be called by code from other classes, modules or (sub)packages of the same app, or they could be called by third-party frameworks such as Pyramid (for example when Pyramid calls an app's views).
+3. Names that are part of the public interface of a class, module or package don't have leading underscores. Internal names that are not part of a class, module or package's public interface **do** have leading underscores.
+
+   For example:
+
+   1. **Classes:** public attributes and methods of a class don't have leading underscores. Internal attributes and methods within a class do have leading underscores.
+   2. **Modules:** public classes, functions and other top-level names within a module don't have leading underscores. Internal attributes, methods and names within a module do have leading underscores.
+   3. **Packages:** public modules within a package don't have leading underscores on their filenames, e.g. `foo.py`. Internal modules within a package do have leading underscores, e.g. `_foo.py`. Similarly public subpackages have no leading underscore (`bar/`), internal subpackages do have a leading underscore (`_bar/`).
 
 ## Aims
 
-We want an approach to laying out our packages that:
+The above approach:
 
 * Differentiates the public interface (that's meant to be called from outside of the package) from internal code.
 
-  Being able to easily see what is public and what is private encourages better code design and makes the code easier to maintain. You can more easily see what a package is "about" if you can see its public interface and ignore internal code until you need to work on it. If you can see that something is internal, you know that it's not going to be used outside of its package. If you've changed a package's internal code but haven't changed its public interface, you know that you won't have broken any code outside of the package.
+  Being able to easily see what is public and what is internal encourages better code design and makes the code easier to maintain. You can more easily see what a package is "about" if you can see its public interface and ignore internal code until you need to work on it. If you can see that something is internal, you know that it's not going to be used outside of its package. If you've changed a package's internal code but haven't changed its public interface, you know that you won't have broken any code outside of the package.
 
 * Provides a place to put internal close collaborators.
 
@@ -32,28 +37,6 @@ We want an approach to laying out our packages that:
   In the past we've used an `<APP>.util` package to contain "utilities" that don't seem to belong anywhere else. This is a terrible pattern because `<APP>.util` becomes an ill-defined grab-bag of all sorts of random stuff, and because anything in `<APP>.util` looks like it might be used anywhere in the code whereas in fact it's likely only used in one place: localization breaks down. We don't want any more `<APP>.util` packages.
 
   Also in the past we've created local `helpers.py` modules or `helpers/` packages within packages to contain the utils or helpers just for that package. This isn't a good pattern either: it still ends up moving close collaborators away from the code that uses them, splitting functions that should live together in one module into separate modules by forcing the helper into `helpers.py`, or splitting modules that should live side-by-side in one package into separate packages by forcing the helper into a `helpers/` subpackage. It's also just annoying to always have to move everything into "helpers" modules.
-
-## Approach
-
-Our approach is simple:
-
-1. Names that are part of a class, module or (sub)package's public interface don't have a leading underscore
-
-2. Names that are **not** part of a class, module or (sub)package's public interface **do** have a leading underscore
-
-3. For example:
-
-   1. **Classes:** public attributes and methods of a class don't have leading underscores. Private attributes and methods within a class do have leading underscores.
-   2. **Modules:** public classes, functions and other top-level names within a module don't have leading underscores. Private attributes, methods and names within a module do have leading underscores.
-   3. **Packages:** public modules within a package don't have leading underscores on their filenames, e.g. `foo.py`. Private modules within a package do have leading underscores, e.g. `_foo.py`. Similarly a public subpackage would have no leading underscore (`bar/`), a private subpackage would have a leading underscore (`_bar/`).
-
-This approach is inspired by [PEP 8](https://www.python.org/dev/peps/pep-0008/)'s guidelines on [public and internal interfaces](https://www.python.org/dev/peps/pep-0008/#public-and-internal-interfaces), which say:
-
-> Even with `__all__` set appropriately, internal interfaces (packages, modules, classes, functions, attributes or other names) should still be prefixed with a single leading underscore.
-> 
-> An interface is also considered internal if any containing namespace (package, module or class) is considered internal.
-
-(A leading underscore is Python's "weak internal use indicator" both for files and directories, and for names within files.)
 
 ## Types of Package in an App
 

--- a/docs/How do we lay out public and private modules in a Python package?.md
+++ b/docs/How do we lay out public and private modules in a Python package?.md
@@ -49,7 +49,8 @@ Generally there are three different types of package within an app:
    * View classes and view methods are public interface: Pyramid calls our views to get responses to requests
      * Exception views are also public interface: Pyramid calls these too
    * Custom view predicates (which get used in Pyramid `@view_config`'s) are public interface: Pyramid calls our view predicates to determine whether to call the view or not
-   * Helper functions that the views call are not public interface: these are only called by other code within the same package. They're not directly called by Pyramid
+
+    Helper functions that the views call are _not_ part of the public interface: these are only called by other code within the same package. They're not directly called by Pyramid
 
    So in the case of an `<APP>.views` package the leading underscores differentiate the views and other things that're registered with Pyramid, from internal helpers. The differentiation helps you to see what views, predicates, etc the app has without being distracted by all their collaborators.
 

--- a/docs/How do we lay out public and private modules in a Python package?.md
+++ b/docs/How do we lay out public and private modules in a Python package?.md
@@ -28,7 +28,7 @@ Pyramid [exception views](https://docs.pylonsproject.org/projects/pyramid/en/lat
 
 ## Importing names into `__init__.py` for convenience
 
-We often import all the names (classes etc) from a package into that package's `__init__.py` file. For example `h/models/__init__.py`:
+We often import all the names from a package into that package's `__init__.py` file. For example `h/models/__init__.py`:
 
 ```python
 from h.models.activation import Activation

--- a/docs/How do we lay out public and private modules in a Python package?.md
+++ b/docs/How do we lay out public and private modules in a Python package?.md
@@ -72,10 +72,10 @@ from pyramid.view import view_config
 
 @view_config(...)
 def foo(request):
-    # Uses _FooHelper.
+    # Uses _FooCollaborator.
     ...
 
-class _FooHelper:
+class _FooCollaborator:
     ...
 ```
 

--- a/docs/How do we lay out public and private modules in a Python package?.md
+++ b/docs/How do we lay out public and private modules in a Python package?.md
@@ -57,7 +57,9 @@ Generally there are three different types of package within an app:
 
 ## Exception Views Module Naming
 
-Pyramid [exception views](https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/views.html#custom-exception-views) present a view-specific code layout issue: you'll probably want to put them in an `exceptions.py` file, but `exceptions.py` is the name that we use in all of our packages for the module that contains that package's exception classes. Decision: just put both custom exception classes (if the `views` package has any) and Pyramid exception views both together in `views/exceptions.py` (no leading underscore)
+Pyramid [exception views](https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/views.html#custom-exception-views) present a view-specific code layout issue: you'll probably want to put them in an `exceptions.py` file, but `exceptions.py` is the name that we use in all of our packages for the module that contains that package's exception classes. 
+
+**Decision**: just put both custom exception classes (if the `views` package has any) and Pyramid exception views both together in `views/exceptions.py` (no leading underscore)
 
 ## In-module collaborators
 

--- a/docs/How do we lay out public and private modules in a Python package?.md
+++ b/docs/How do we lay out public and private modules in a Python package?.md
@@ -79,7 +79,7 @@ class _FooCollaborator:
     ...
 ```
 
-With a close-collaborator like this the unit tests would normally work by calling the `foo()` view and only testing `_FooHelper` indirectly via the `foo()` view. A close collaborator like `_FooHelper` wouldn't normally be patched in the unit tests for the `foo()` view.
+With a close-collaborator like this the unit tests would normally work by calling the `foo()` view and only testing `_FooHelper` indirectly via the `foo()` view. A close collaborator like `_FooCollaborator` wouldn't normally be patched in the unit tests for the `foo()` view.
 
 Reasons **not** to do put a collaborator in-module:
 

--- a/docs/How do we lay out public and private modules in a Python package?.md
+++ b/docs/How do we lay out public and private modules in a Python package?.md
@@ -1,0 +1,86 @@
+# How do we lay out public and internal modules in a Python package?
+
+See also:
+
+* [Organization of views package is poor](https://github.com/hypothesis/lms/issues/1245), the original issue that led to this file
+
+We follow [PEP 8](https://www.python.org/dev/peps/pep-0008/)'s guidelines on [public and internal interfaces](https://www.python.org/dev/peps/pep-0008/#public-and-internal-interfaces), which say:
+
+> Even with `__all__` set appropriately, internal interfaces (packages, modules, classes, functions, attributes or other names) should still be prefixed with a single leading underscore.
+> 
+> An interface is also considered internal if any containing namespace (package, module or class) is considered internal.
+
+(A leading underscore is Python's "weak internal use indicator" both for files and directories, and for names within files.)
+
+Let's take a Pyramid app's `views` package as an example, although this should apply equally well to any package:
+
+* A `views` package arguably doesn't really have a "public interface": it doesn't contain any code that's meant to be imported and used by other parts of our code. But the views in a `views` package are called by Pyramid so we consider those (and other `views`-package objects that are for Pyramid to call) to be the `views` package's public interface. The same thinking also applies to other packages that just contain things for Pyramid to call
+
+* So files in a `views` package that contain views are considered public and **don't have a leading underscore**. E.g. the foo views would be `views/foo.py`
+
+* Collaborators for the views are only meant to be called by the views themselves and so are internal. These **do have a leading underscore**. E.g. the bar helpers would be `views/_bar.py`
+
+* This use of leading underscores makes it easy to tell which files contain views, and which just contain internal collaborators for the views. Or in a `services` package it would make it easy to tell which files contain services, and which just contain internal collaborators for the services. In a package that contains objects that are actually supposed to be imported and used by our own code (not just called by Pyramid) the leading underscores also denote which modules contain things that are meant to be imported elsewhere in the code and which are for internal use only
+
+* Pyramid [exception views](https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/views.html#custom-exception-views) present a view-specific code layout issue: you'll probably want to put them in an `exceptions.py` file, but `exceptions.py` is the name that we use in all of our packages for the module that contains that package's exception classes. Decision: just put both custom exception classes (if the `views` package has any) and Pyramid exception views both together in `views/exceptions.py` (no leading underscore)
+
+## In-module collaborators
+
+Although you can put collaborators in their own `_bar.py` module alongside the module(s) that call them, if some collaborators are only used within one module it's also fine to just put them in that module:
+
+```python
+# views/foo.py
+
+from pyramid.view import view_config
+
+@view_config(...)
+def foo(request):
+    # Uses _FooHelper.
+    ...
+
+class _FooHelper:
+    ...
+```
+
+With a close-collaborator like this the unit tests would normally work by calling the `foo()` view and only testing `_FooHelper` indirectly via the `foo()` view. A close collaborator like `_FooHelper` wouldn't normally be patched in the unit tests for the `foo()` view.
+
+Reasons **not** to do put a collaborator in-module:
+
+* If `_FooHelper` is called by anything outside of `views/foo.py`
+* If it would make either `views/foo.py` or its unit tests too long (lots of small collaborating files, rather than a few big ones, please)
+
+## Importing names into an `__init__.py` file
+
+We often import all the names (classes etc) from a module into that module's `__init__.py` file. For example `h/models/__init__.py`:
+
+```python
+from h.models.activation import Activation
+from h.models.annotation import Annotation
+from h.models.annotation_moderation import AnnotationModeration
+...
+```
+
+This is done for convenience:
+
+1. User code can just do `from h.models import Annotation, Group, User` instead of having to do `from h.models.annotation import Annotation` and `from h.models.group import Group` and `from h.models.user import User`
+
+2. It makes it easier when you want to reorganize the code within the `h.models` package. For example renaming a module, splitting a large module into two smaller ones, or joining two modules into one. Code that does `from h.models import Annotation, Group, User` won't be broken by the reorganization
+
+### This doesn't mean every module is internal
+
+You might think that, since `Annotation`, `Group` and `User` are meant to be imported from `models/__init__.py` rather than from `models/annotation.py`, `models/group.py` and `models/user.py`, that `models/annotation.py`, `models/group.py` and `models/user.py` are actually internal and should have leading underscores. Don't think this, though, because it would mean that:
+
+1. Every module in every package would have a leading underscore
+2. The leading underscores would no longer be helping us to distinguish between modules that contain public things and modules that only contain internal collaborators
+
+## We don't use `__all__`
+
+PEP 8 [says](https://www.python.org/dev/peps/pep-0008/#public-and-internal-interfaces):
+
+> To better support introspection, modules should explicitly declare the names in their public API using the `__all__` attribute.
+
+We don't put `__all__`'s in our modules because we haven't found it to be useful. For example we don't have any modules that're designed to be used via `from <module> import *` (an `__all__` controls what names `import *` imports from a module). And we haven't found any introspection benefits to `__all__`.
+
+Instead we just put leading underscores on internal names, and no leading underscores on public names.
+
+If you ever have a need to make an underscored name public, or a non-underscored name internal, and you can't rename to add or remove the leading underscore, then use a docstring or code comment to say that the name is public or internal despite the (lack of) a leading underscore

--- a/docs/How do we lay out public and private modules in a Python package?.md
+++ b/docs/How do we lay out public and private modules in a Python package?.md
@@ -11,6 +11,10 @@ Packages are a way of structuring the module namespace within a containing packa
 
 Some packages can be installed and might even be published to the [Python Package Index (PyPI.org)](https://pypi.org/). **This document isn't limited to just installable packages** -- packages and subpackages within a containing package or app are also "packages" for this document's purposes.
 
+## What Is a "Public Interface"?
+
+For the purposes of this document the "public interface" of a class, module or package is all the names that are meant to be used by **code outside of that class, module or package**. The public names could be called by code from other classes, modules or (sub)packages of the same app, or they could be called by third-party frameworks such as Pyramid (for example when Pyramid calls an app's views).
+
 ## Aims
 
 We want an approach to laying out our packages that:
@@ -37,9 +41,7 @@ Our approach is simple:
 
 2. Names that are **not** part of a class, module or (sub)package's public interface **do** have a leading underscore
 
-3. The "public interface" of a class, module or (sub)package means all the names that are meant to be called by **code outside of that package**. The public names could be called by code from other class, modules or (sub)packages of the same app, or they could be called by third-party frameworks such as Pyramid (for example when Pyramid calls an app's views), etc.
-
-4. For example:
+3. For example:
 
    1. **Classes:** public attributes and methods of a class don't have leading underscores. Private attributes and methods within a class do have leading underscores.
    2. **Modules:** public classes, functions and other top-level names within a module don't have leading underscores. Private attributes, methods and names within a module do have leading underscores.

--- a/docs/How do we lay out public and private modules in a Python package?.md
+++ b/docs/How do we lay out public and private modules in a Python package?.md
@@ -83,7 +83,7 @@ With a close-collaborator like this the unit tests would normally work by callin
 
 Reasons **not** to do put a collaborator in-module:
 
-* If `_FooHelper` is called by anything outside of `views/foo.py`
+* If `_FooCollaborator` is called by anything outside of `views/foo.py`
 * If it would make either `views/foo.py` or its unit tests too long (lots of small collaborating files, rather than a few big ones, please)
 
 ## Importing names into an `__init__.py` file


### PR DESCRIPTION
Based on https://github.com/hypothesis/lms/issues/1245 but expanded to apply to any Python package, and adding details aboout `__init__.py` and `__all__`