### PR TITLE
Add h, coverage, isort and untracked files support

### DIFF
--- a/bin/qt
+++ b/bin/qt
@@ -17,9 +17,13 @@ class StandardProject:
 
         Includes both committed and uncommitted, staged and unstaged changes.
 
+        If a source file has been modified then its corresponding unit test
+        file will be included even if the unit test file itself hasn't been
+        modified, and vice-versa.
+
         FIXME: This should also include untracked files.
         """
-        return set(
+        modified_files = set(
             subprocess.run(
                 ["git", "diff", "origin/master", "--name-only"],
                 check=True,
@@ -28,6 +32,20 @@ class StandardProject:
             .stdout.decode("utf8")
             .split()
         )
+
+        files = set(modified_files)
+
+        for f in modified_files:
+            if self.is_src_file(f):
+                test_filename = self.test_filename(f)
+                if os.path.exists(test_filename):
+                    files.add(test_filename)
+            elif self.is_unit_test_file(f):
+                src_filename = self.src_filename(f)
+                if os.path.exists(src_filename):
+                    files.add(src_filename)
+
+        return files
 
     @lru_cache()
     def is_python_file(self, filename):
@@ -95,6 +113,17 @@ class StandardProject:
         """
         return "tests/unit/" + os.path.splitext(filename)[0] + "_test.py"
 
+    @lru_cache()
+    def src_filename(self, filename):
+        """
+        Return the source filename for the given test `filename`.
+
+        This doesn't check that the returned source filename actually exists:
+        it just returns the path to where the source file _should_ be according
+        to the project's file layout conventions.
+        """
+        return filename[len("tests/unit/") :][: -len("_test.py")] + ".py"
+
     def format(self):
         """Run the formatter(s) on all modified files."""
         if not self.python_files:
@@ -116,7 +145,20 @@ class StandardProject:
     def run_unit_tests(self):
         """Run the unit tests for all modified files."""
         if self.unit_test_files:
-            self.run("tests", "pytest", self.unit_test_files)
+            self.run("tests", "coverage run -m pytest", self.unit_test_files)
+
+    def run_coverage(self):
+        """Print a coverage report for all modified files."""
+        if not self.python_files:
+            return
+
+        self.run("tests", "coverage combine", [])
+        self.run(
+            "tests",
+            "coverage report",
+            [],
+            "--fail-under=0 --no-skip-covered --include " + ",".join(self.python_files),
+        )
 
     def run_functional_tests(self):
         """Run all modified functional test files."""
@@ -128,6 +170,7 @@ class StandardProject:
         self.format()
         self.lint()
         self.run_unit_tests()
+        self.run_coverage()
         self.run_functional_tests()
 
 

--- a/bin/qt
+++ b/bin/qt
@@ -131,6 +131,21 @@ class StandardProject:
         self.run_functional_tests()
 
 
+class HProject(StandardProject):
+    @lru_cache()
+    def is_unit_test_file(self, filename):
+        """Return True if `filename` is a unit test file."""
+        return filename.startswith("tests/h")
+
+    def lint(self):
+        """Run the linter(s) on all modified files."""
+        if self.src_files:
+            self.run("lint", "flake8", self.src_files)
+
+        if self.test_files:
+            self.run("lint", "flake8", self.test_files)
+
+
 class Run:
     def __init__(self, tox, verbose):
         self._tox = tox
@@ -180,7 +195,12 @@ def main():
 
     args = parser.parse_args()
 
-    StandardProject(args.tox, args.verbose).run_all()
+    if os.path.isdir("h"):
+        ProjectClass = HProject
+    else:
+        ProjectClass = StandardProject
+
+    ProjectClass(args.tox, args.verbose).run_all()
 
 
 if __name__ == "__main__":

--- a/bin/qt
+++ b/bin/qt
@@ -129,8 +129,8 @@ class StandardProject:
         if not self.python_files:
             return
 
-        # FIXME: This should also run isort.
         self.run("format", "black", self.python_files)
+        self.run("format", "isort --quiet --atomic", self.python_files)
 
     def lint(self):
         """Run the linter(s) on all modified files."""

--- a/bin/qt
+++ b/bin/qt
@@ -144,11 +144,13 @@ class StandardProject:
         """Run the linter(s) on all modified files."""
         if self.src_files:
             self.run("lint", "pylint", self.src_files)
-            self.run("lint", "pycodestyle", self.src_files)
-            self.run("lint", "pydocstyle", self.src_files)
 
         if self.test_files:
             self.run("lint", "pylint", self.test_files, "--rcfile=tests/.pylintrc")
+
+        if self.python_files:
+            self.run("lint", "pycodestyle", self.python_files)
+            self.run("lint", "pydocstyle", self.python_files)
 
     def run_unit_tests(self):
         """Run the unit tests for all modified files."""

--- a/bin/qt
+++ b/bin/qt
@@ -185,6 +185,11 @@ class StandardProject:
 
 
 class HProject(StandardProject):
+    @staticmethod
+    def is_current_project():
+        """True if this class should be used for the current project."""
+        return os.path.isdir("h")
+
     @lru_cache()
     def is_unit_test_file(self, filename):
         """Return True if `filename` is a unit test file."""
@@ -248,12 +253,14 @@ def main():
 
     args = parser.parse_args()
 
-    if os.path.isdir("h"):
-        ProjectClass = HProject
-    else:
-        ProjectClass = StandardProject
+    current_project_class = StandardProject
 
-    ProjectClass(args.tox, args.verbose).run_all()
+    for project_class in [HProject]:
+        if project_class.is_current_project():
+            current_project_class = project_class
+            break
+
+    current_project_class(args.tox, args.verbose).run_all()
 
 
 if __name__ == "__main__":

--- a/bin/qt
+++ b/bin/qt
@@ -9,6 +9,31 @@ class StandardProject:
     def __init__(self, tox, verbose):
         self.run = Run(tox, verbose)
 
+    @lru_cache()
+    def is_python_file(self, filename):
+        """Return True if `filename` is a Python file."""
+        return filename.endswith(".py")
+
+    @lru_cache()
+    def is_src_file(self, filename):
+        """Return True if `filename` is a source file (as opposed to a test file)."""
+        return not self.is_test_file(filename)
+
+    @lru_cache()
+    def is_test_file(self, filename):
+        """Return True if `filename` is a test file."""
+        return filename.startswith("tests/")
+
+    @lru_cache()
+    def is_unit_test_file(self, filename):
+        """Return True if `filename` is a unit test file."""
+        return filename.startswith("tests/unit")
+
+    @lru_cache()
+    def is_functest_file(self, filename):
+        """Return True if `filename` is a functional test file."""
+        return filename.startswith("tests/functional")
+
     @property
     @lru_cache()
     def files(self):
@@ -56,31 +81,6 @@ class StandardProject:
                     files.add(src_filename)
 
         return files
-
-    @lru_cache()
-    def is_python_file(self, filename):
-        """Return True if `filename` is a Python file."""
-        return filename.endswith(".py")
-
-    @lru_cache()
-    def is_src_file(self, filename):
-        """Return True if `filename` is a source file (as opposed to a test file)."""
-        return not self.is_test_file(filename)
-
-    @lru_cache()
-    def is_test_file(self, filename):
-        """Return True if `filename` is a test file."""
-        return filename.startswith("tests/")
-
-    @lru_cache()
-    def is_unit_test_file(self, filename):
-        """Return True if `filename` is a unit test file."""
-        return filename.startswith("tests/unit")
-
-    @lru_cache()
-    def is_functest_file(self, filename):
-        """Return True if `filename` is a functional test file."""
-        return filename.startswith("tests/functional")
 
     @property
     @lru_cache()

--- a/bin/qt
+++ b/bin/qt
@@ -78,37 +78,37 @@ class StandardProject:
                 if os.path.exists(src_filename):
                     files.add(src_filename)
 
-        return files
+        return sorted(files)
 
     @property
     @lru_cache()
     def python_files(self):
         """All Python files modified on this branch compared to master."""
-        return set(f for f in self.files if self.is_python_file(f))
+        return [f for f in self.files if self.is_python_file(f)]
 
     @property
     @lru_cache()
     def src_files(self):
         """All source files modified on this branch compared to master."""
-        return set(f for f in self.python_files if self.is_src_file(f))
+        return [f for f in self.python_files if self.is_src_file(f)]
 
     @property
     @lru_cache()
     def test_files(self):
         """All test files modified on this branch compared to master."""
-        return set(f for f in self.python_files if self.is_test_file(f))
+        return [f for f in self.python_files if self.is_test_file(f)]
 
     @property
     @lru_cache()
     def unit_test_files(self):
         """All unit test files modified on this branch compared to master."""
-        return set(f for f in self.python_files if self.is_unit_test_file(f))
+        return [f for f in self.python_files if self.is_unit_test_file(f)]
 
     @property
     @lru_cache()
     def func_test_files(self):
         """All functional test files modified on this branch compared to master."""
-        return set(f for f in self.python_files if self.is_functest_file(f))
+        return [f for f in self.python_files if self.is_functest_file(f)]
 
     @lru_cache()
     def test_filename(self, filename):

--- a/bin/qt
+++ b/bin/qt
@@ -45,8 +45,6 @@ class StandardProject:
         If a source file has been modified then its corresponding unit test
         file will be included even if the unit test file itself hasn't been
         modified, and vice-versa.
-
-        FIXME: This should also include untracked files.
         """
         modified_files = set(
             subprocess.run(

--- a/bin/qt
+++ b/bin/qt
@@ -2,38 +2,133 @@
 import argparse
 import os
 import subprocess
+from functools import lru_cache
 
 
-def get_files():
-    files = (
-        subprocess.run(
-            ["git", "diff", "origin/master", "--name-only"],
-            check=True,
-            stdout=subprocess.PIPE,
+class StandardProject:
+    def __init__(self, tox, verbose):
+        self.run = Run(tox, verbose)
+
+    @property
+    @lru_cache()
+    def files(self):
+        """
+        All files modified on this branch compared to master.
+
+        Includes both committed and uncommitted, staged and unstaged changes.
+
+        FIXME: This should also include untracked files.
+        """
+        return set(
+            subprocess.run(
+                ["git", "diff", "origin/master", "--name-only"],
+                check=True,
+                stdout=subprocess.PIPE,
+            )
+            .stdout.decode("utf8")
+            .split()
         )
-        .stdout.decode("utf8")
-        .split()
-    )
 
-    files = [f for f in files if f.endswith(".py")]
+    @lru_cache()
+    def is_python_file(self, filename):
+        """Return True if `filename` is a Python file."""
+        return filename.endswith(".py")
 
-    for f in files:
-        if f.startswith("tests/"):
-            continue
+    @lru_cache()
+    def is_src_file(self, filename):
+        """Return True if `filename` is a source file (as opposed to a test file)."""
+        return not self.is_test_file(filename)
 
-        test_file = "tests/unit/" + os.path.splitext(f)[0] + "_test.py"
+    @lru_cache()
+    def is_test_file(self, filename):
+        """Return True if `filename` is a test file."""
+        return filename.startswith("tests/")
 
-        if test_file not in files:
-            files.append(test_file)
+    @lru_cache()
+    def is_unit_test_file(self, filename):
+        """Return True if `filename` is a unit test file."""
+        return filename.startswith("tests/unit")
 
-    files = [f for f in files if os.path.isfile(f)]
+    @lru_cache()
+    def is_functest_file(self, filename):
+        """Return True if `filename` is a functional test file."""
+        return filename.startswith("tests/functional")
 
-    test_files = [f for f in files if f.startswith("tests/unit/")]
-    functest_files = [f for f in files if f.startswith("tests/functional/")]
-    all_test_files = test_files + functest_files
-    src_files = [f for f in files if f not in all_test_files]
+    @property
+    @lru_cache()
+    def python_files(self):
+        """All Python files modified on this branch compared to master."""
+        return set(f for f in self.files if self.is_python_file(f))
 
-    return files, src_files, test_files, functest_files, all_test_files
+    @property
+    @lru_cache()
+    def src_files(self):
+        """All source files modified on this branch compared to master."""
+        return set(f for f in self.python_files if self.is_src_file(f))
+
+    @property
+    @lru_cache()
+    def test_files(self):
+        """All test files modified on this branch compared to master."""
+        return set(f for f in self.python_files if self.is_test_file(f))
+
+    @property
+    @lru_cache()
+    def unit_test_files(self):
+        """All unit test files modified on this branch compared to master."""
+        return set(f for f in self.python_files if self.is_unit_test_file(f))
+
+    @property
+    @lru_cache()
+    def func_test_files(self):
+        """All functional test files modified on this branch compared to master."""
+        return set(f for f in self.python_files if self.is_functest_file(f))
+
+    @lru_cache()
+    def test_filename(self, filename):
+        """
+        Return the test filename for the given source `filename`.
+
+        This doesn't check that the returned test filename actually exists: it
+        just returns the path to where the test file _should_ be according to
+        the project's file layout conventions.
+        """
+        return "tests/unit/" + os.path.splitext(filename)[0] + "_test.py"
+
+    def format(self):
+        """Run the formatter(s) on all modified files."""
+        if not self.python_files:
+            return
+
+        # FIXME: This should also run isort.
+        self.run("format", "black", self.python_files)
+
+    def lint(self):
+        """Run the linter(s) on all modified files."""
+        if self.src_files:
+            self.run("lint", "pylint", self.src_files)
+            self.run("lint", "pycodestyle", self.src_files)
+            self.run("lint", "pydocstyle", self.src_files)
+
+        if self.test_files:
+            self.run("lint", "pylint", self.test_files, "--rcfile=tests/.pylintrc")
+
+    def run_unit_tests(self):
+        """Run the unit tests for all modified files."""
+        if self.unit_test_files:
+            self.run("tests", "pytest", self.unit_test_files)
+
+    def run_functional_tests(self):
+        """Run all modified functional test files."""
+        if self.func_test_files:
+            self.run("functests", "pytest", self.func_test_files)
+
+    def run_all(self):
+        """Run all the checks for all the modified files."""
+        self.format()
+        self.lint()
+        self.run_unit_tests()
+        self.run_functional_tests()
 
 
 class Run:
@@ -85,26 +180,7 @@ def main():
 
     args = parser.parse_args()
 
-    files, src_files, test_files, functest_files, all_test_files = get_files()
-
-    if files:
-        run = Run(args.tox, args.verbose)
-
-        run("format", "black", files)
-
-        if src_files:
-            run("lint", "pylint", src_files)
-            run("lint", "pycodestyle", src_files)
-            run("lint", "pydocstyle", src_files)
-
-        if all_test_files:
-            run("lint", "pylint", all_test_files, "--rcfile=tests/.pylintrc")
-
-        if test_files:
-            run("tests", "pytest", test_files)
-
-        if functest_files:
-            run("functests", "pytest", functest_files)
+    StandardProject(args.tox, args.verbose).run_all()
 
 
 if __name__ == "__main__":

--- a/bin/qt
+++ b/bin/qt
@@ -33,7 +33,17 @@ class StandardProject:
             .split()
         )
 
-        files = set(modified_files)
+        untracked_files = set(
+            subprocess.run(
+                ["git", "ls-files", "--others", "--exclude-standard"],
+                check=True,
+                stdout=subprocess.PIPE,
+            )
+            .stdout.decode("utf8")
+            .split()
+        )
+
+        files = modified_files.union(untracked_files)
 
         for f in modified_files:
             if self.is_src_file(f):


### PR DESCRIPTION
* Add h support:
  * Refactor to move most of the code into a `StandardProject` class
  * The `StandardProject` class is broken down into lots of little properties and methods with names and docstrings. This should both make the code easy to understand, and make it easy for subclasses to customize by overriding only certain things:
    * `is_*` methods like `is_src_file(filename)`, `is_unit_test_file(filename)`, etc.
    * `*_files` properties like `files()`, `python_files()`, `test_files()`, etc.
    * Action methods like `format()`, `lint()`, `run_unit_tests()`, etc.
  * Add an `HProject` class that subclasses `StandardProject` and overrides just the parts necessary to make it work in h
  * Have the `main()` method detect whether we're in h (by the presence of an `h` subdir) and use `StandardProject` or `HProject` accordingly
* Add support for finding the corresponding source code file if only the unit test file has been modified, and vice-versa. These corresponding files get passed to all the commands (lint, test, coverage)
* Add coverage support
* Add isort support
* Include untracked files